### PR TITLE
Fixing Regex to match all cursor events

### DIFF
--- a/ghec-audit-log-utils.js
+++ b/ghec-audit-log-utils.js
@@ -17,7 +17,7 @@ function validateInput (program, config) {
 
   // Validate correctness
   const tokenRegex = /^[g(p|o|u|s|r)1_]{0,1}[A-Za-z0-9_]+$/
-  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})'
+  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?'
   const orgRegex = /^[a-z\d]+(?:-?[a-z\d]+)*$/i
   const constraints = {
     cursor: {

--- a/ghec-audit-log-utils.js
+++ b/ghec-audit-log-utils.js
@@ -17,7 +17,7 @@ function validateInput (program, config) {
 
   // Validate correctness
   const tokenRegex = /^[g(p|o|u|s|r)1_]{0,1}[A-Za-z0-9_]+$/
-  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?'
+  const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
   const orgRegex = /^[a-z\d]+(?:-?[a-z\d]+)*$/i
   const constraints = {
     cursor: {

--- a/ghec-audit-log-utils.js
+++ b/ghec-audit-log-utils.js
@@ -17,7 +17,7 @@ function validateInput (program, config) {
 
   // Validate correctness
   const tokenRegex = /^[g(p|o|u|s|r)1_]{0,1}[A-Za-z0-9_]+$/
-  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$'
+  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})'
   const orgRegex = /^[a-z\d]+(?:-?[a-z\d]+)*$/i
   const constraints = {
     cursor: {

--- a/ghec-audit-log-utils.js
+++ b/ghec-audit-log-utils.js
@@ -17,7 +17,7 @@ function validateInput (program, config) {
 
   // Validate correctness
   const tokenRegex = /^[g(p|o|u|s|r)1_]{0,1}[A-Za-z0-9_]+$/
-  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)'
+  const base64Regex = '(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$'
   const orgRegex = /^[a-z\d]+(?:-?[a-z\d]+)*$/i
   const constraints = {
     cursor: {


### PR DESCRIPTION
While testing this internally I discovered a bug that would throw an invalid cursor error on certain base64 cursor events.

Valid:

MDIxOlJlcG9EZXN0cm95QXVkaXRFbnRyeWFxNE5hT3JjbDZLSDZKWmViWlZIdkE7MjAyMS0wNTtkdw==

Invalid:

MDIzOlJlcG9BZGRNZW1iZXJBdWRpdEVudHJ5d0ZLYXA0MldwZWRzZ2EwVlZaNGdKQTsyMDIxLTA1O2R3

This regex modification fixes that. 