### PR TITLE
Fix .gitignore conflict with workflow step

### DIFF
--- a/workflows/forward-v3-workflow.yml
+++ b/workflows/forward-v3-workflow.yml
@@ -61,6 +61,6 @@ jobs:
         author_name: Audit Log Integration
         author_email: ${{ secrets.COMMITTER_EMAIL }}
         message: "Updating cursor for audit log"
-        add: ".last-v3-cursor-update"
+        add: ".last-v3-cursor-update --force"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/forward-v4-workflow.yml
+++ b/workflows/forward-v4-workflow.yml
@@ -61,6 +61,6 @@ jobs:
         author_name: Audit Log Integration
         author_email: ${{ secrets.COMMITTER_EMAIL }}
         message: "Updating cursor for audit log"
-        add: ".last-cursor-update"
+        add: ".last-cursor-update --force"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The repo's .gitignore has an entry for `.last-cursor-update` and `.last-v3-cursor-update` which causes the current workflow examples to fail when trying to commit the new cursor back into the repo.

By adding `--force` to `git add` the workflows can add the latest cursor without the `.gitignore` file blocking the commit.

