### PR TITLE
Fix LAST_CURSOR check logic

### DIFF
--- a/workflows/forward-v3-workflow.yml
+++ b/workflows/forward-v3-workflow.yml
@@ -34,10 +34,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # Configure the cursor endpoint
-    - name: Export Cursor
-      run: export LAST_CURSOR=$(cat .last-v3-cursor-update)
-
     # Need to install NPM
     - name: NPM Install
       run: npm install
@@ -45,6 +41,10 @@ jobs:
       # If this is the first time we poll, then do a fresh poll. If not, poll from latest cursor.
     - name: Poll from Cursor
       run: |
+        if [ -f ".last-v3-cursor-update" ]; then
+          LAST_CURSOR=$(cat .last-v3-cursor-update)
+        fi
+
         if [ -z "$LAST_CURSOR" ]; then
           echo "FIRST TIME RUNNING AUDIT LOG POLL"
           npm start -- --token ${{secrets.AUDIT_LOG_TOKEN}} --org ${{secrets.ORG_NAME}} --api 'v3' --api-type 'all' --file 'audit-log-output.json'

--- a/workflows/forward-v4-workflow.yml
+++ b/workflows/forward-v4-workflow.yml
@@ -34,10 +34,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # Configure the cursor endpoint
-    - name: Export Cursor
-      run: export LAST_CURSOR=$(cat .last-cursor-update)
-
     # Need to install NPM
     - name: NPM Install
       run: npm install
@@ -45,6 +41,10 @@ jobs:
       # If this is the first time we poll, then do a fresh poll. If not, poll from latest cursor.
     - name: Poll from Cursor
       run: |
+        if [ -f ".last-cursor-update" ]; then
+          LAST_CURSOR=$(cat .last-cursor-update)
+        fi
+
         if [ -z "$LAST_CURSOR" ]; then
           echo "FIRST TIME RUNNING AUDIT LOG POLL"
           npm start -- --token ${{secrets.AUDIT_LOG_TOKEN}} --org ${{secrets.ORG_NAME}} --file 'audit-log-output.json'


### PR DESCRIPTION
the `LAST_CURSOR` environment variable is lost between steps causing the Poll from Cursor step to always pull all of the audit logs.

I couldn't find this documented anywhere, but I confirmed it using printev in each step.

Adding the `LAST_CURSOR` variable in the same step as the poll fixes this issue. A conditional statement is added to verify the file exists before getting the content because `cat` with an invalid src file will cause the step to error out.
