### PR TITLE
Fix `git clone` URL of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ node audit-log-ghec-cli --pretty
 Optionally you can install the script as a CLI and run it from the command line. To install it run:
 
 ```shell script
-$ git clone https://github.com/droidpl/ghec-audit-log-cli
+$ git clone https://github.com/github/ghec-audit-log-cli
 $ cd ghec-audit-log-cli
 $ npm link
 ```


### PR DESCRIPTION
Hi @droidpl 👋 

I found that the `git clone` URL of the README.md file still points to https://github.com/droidpl/ghec-audit-log-cli.
However the URL is redirected to this repo (I guess you transferred your repo to GitHub org?), I think replacing the URL would make the installation guidance more clear for users.