### PR TITLE
Fix `node` command example of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ npm run start -- --pretty
 ### node
 
 ```shell script
-$ node audit-log-ghec-cli --pretty
+$ node ghec-audit-log-cli --pretty
 ```
 
 ## Installing as CLI


### PR DESCRIPTION
Hi again @droidpl 👋 

I noticed that the command example below doesn't work because of the script name.

```
$ node audit-log-ghec-cli --pretty
```

I'm not sure why but changing script name fixes the problem.
This pull request updates the command example of the README.md file.

<details><summary>Tested on Docker container</summary>

# `node audit-log-ghec-cli` fails

```
docker run -it --rm node:lts bash -c 'git clone https://github.com/github/ghec-audit-log-cli && cd ghec-audit-log-cli && npm link && node audit-log-ghec-cli --help'
Cloning into 'ghec-audit-log-cli'...
remote: Enumerating objects: 333, done.
remote: Counting objects: 100% (146/146), done.
remote: Compressing objects: 100% (107/107), done.
remote: Total 333 (delta 83), reused 75 (delta 39), pack-reused 187
Receiving objects: 100% (333/333), 200.65 KiB | 0 bytes/s, done.
Resolving deltas: 100% (182/182), done.
added 274 packages from 168 contributors and audited 274 packages in 6.474s

43 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/usr/local/bin/ghec-audit-log-cli -> /usr/local/lib/node_modules/ghec-audit-log-cli/ghec-audit-log-cli.js
/usr/local/lib/node_modules/ghec-audit-log-cli -> /ghec-audit-log-cli
internal/modules/cjs/loader.js:888
  throw err;
  ^

Error: Cannot find module '/ghec-audit-log-cli/audit-log-ghec-cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

# `node ghec-audit-log-cli` succeeds

```
docker run -it --rm node:lts bash -c 'git clone https://github.com/github/ghec-audit-log-cli && cd ghec-audit-log-cli && npm link && node ghec-audit-log-cli --help'
Cloning into 'ghec-audit-log-cli'...
remote: Enumerating objects: 333, done.
remote: Counting objects: 100% (146/146), done.
remote: Compressing objects: 100% (107/107), done.
remote: Total 333 (delta 83), reused 75 (delta 39), pack-reused 187
Receiving objects: 100% (333/333), 200.65 KiB | 0 bytes/s, done.
Resolving deltas: 100% (182/182), done.
added 274 packages from 168 contributors and audited 274 packages in 6.21s

43 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/usr/local/bin/ghec-audit-log-cli -> /usr/local/lib/node_modules/ghec-audit-log-cli/ghec-audit-log-cli.js
/usr/local/lib/node_modules/ghec-audit-log-cli -> /ghec-audit-log-cli
Usage: ghec-audit-log-cli [options]

Options:
  -v, --version             Output the current version
  -t, --token <string>      the token to access the API (mandatory)
  -o, --org <string>        the organization we want to extract the audit log from
  -cfg, --config <string>   location for the config yaml file. Default ".ghec-audit-log" (default: "./.ghec-audit-log")
  -p, --pretty              prints the json data in a readable format (default: false)
  -l, --limit <number>      a maximum limit on the number of items retrieved
  -f, --file <string>       the output file where the result should be printed
  -a, --api <string>        the version of GitHub API to call (default: "v4")
  -at, --api-type <string>  Only if -a is v3. API type to bring, either all, web or git (default: "all")
  -c, --cursor <string>     if provided, this cursor will be used to query the newest entries from the cursor provided. If not present, the result will contain all the audit log
                            from the org
  -s, --source <string>     the source of the audit log. The source can be either a GitHub Enterprise or a GitHub Enterprise Organization. Accepts the following values: org |
                            enterprise. Defaults to org (default: "org")
  -h, --help                display help for command

```

</details>