### PR TITLE
Add `npm install` instruction at the _Running the CLI_ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ If you are running this utility against a GHEC account, we recommend that you cr
 
 ## Running the CLI
 
-Execute the command using node or npm. Before to execute, run `npm install` to install dependencies.
+Execute the command using node or npm
+
+### Pre-requisites
+
+ Install the node dependencies:
 
 ```shell script
 $ git clone https://github.com/github/ghec-audit-log-cli
 $ cd ghec-audit-log-cli
 $ npm install
-```
 
 ### npm
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Execute the command using node or npm
 $ git clone https://github.com/github/ghec-audit-log-cli
 $ cd ghec-audit-log-cli
 $ npm install
+```
 
 ### npm
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ If you are running this utility against a GHEC account, we recommend that you cr
 
 ## Running the CLI
 
-Execute the command using node or npm.
+Execute the command using node or npm. Before to execute, run `npm install` to install dependencies.
+
+```shell script
+$ git clone https://github.com/github/ghec-audit-log-cli
+$ cd ghec-audit-log-cli
+$ npm install
+```
 
 ### npm
 


### PR DESCRIPTION
Hi @droidpl 👋 

When I tried to use `ghec-audit-log-cli` first time, I got an error like this.

```
$ git clone https://github.com/github/ghec-audit-log-cli
$ cd ghec-audit-log-cli
$ node ghec-audit-log-cli -v
internal/modules/cjs/loader.js:888
  throw err;
  ^

Error: Cannot find module 'yaml'
Require stack:
- /ghec-audit-log-cli/ghec-audit-log-cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Module.require (internal/modules/cjs/loader.js:957:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/ghec-audit-log-cli/ghec-audit-log-cli.js:2:14)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/ghec-audit-log-cli/ghec-audit-log-cli.js' ]
}
```

That's because the node modules hadn't installed yet.

Because I am not familiar with Node.js ecosystem, I wasn't aware that I need to run `npm install` before executing the command.

Although the _Installing as CLI_ section mentions to run `npm link`, I think it's for the different purpose. So that I think it's worth adding `npm install` instruction to the _Running the CLI_ section.

This pull request adds `npm install` instruction to the _Running the CLI_ section of the `README.md`.