### PR TITLE
Get version number from `package.json`

### DIFF
--- a/ghec-audit-log-cli.js
+++ b/ghec-audit-log-cli.js
@@ -10,7 +10,8 @@ const { validateInput } = require('./ghec-audit-log-utils')
 
 // Obtain configuration
 const { program } = require('commander')
-program.version('1.0.0', '-v, --version', 'Output the current version')
+const mypackage = require('./package.json')
+program.version(mypackage.version, '-v, --version', 'Output the current version')
   .option('-t, --token <string>', 'the token to access the API (mandatory)')
   .option('-o, --org <string>', 'the organization we want to extract the audit log from')
   .option('-cfg, --config <string>', 'location for the config yaml file. Default ".ghec-audit-log"', './.ghec-audit-log')


### PR DESCRIPTION
Hi, I found that the version number in [package.json](https://github.com/github/ghec-audit-log-cli/blob/6ac03117aa7e86a14f408981040f7d1ea88b4001/package.json#L3) and [ghec-audit-log-cli.js](https://github.com/github/ghec-audit-log-cli/blob/6ac03117aa7e86a14f408981040f7d1ea88b4001/ghec-audit-log-cli.js#L13) are inconsistent.

This pull request unifies them.

```
❯ node ghec-audit-log-cli.js --version
2.0.0
```

```
❯ npm link

❯ ghec-audit-log-cli --version
2.0.0
```

I found another inconsistency between package.json's version number and the [latest release](https://github.com/github/ghec-audit-log-cli/releases/tag/2.1.1)'s version number but this pull request won't fix it because it should be covered by the release workflow of this project.

